### PR TITLE
fix: use named exports for tinyglobby

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "rimraf": "^3.0.2",
         "split2": "^4.2.0",
         "tar-fs": "^2.1.1",
-        "tinyglobby": "^0.2.0"
+        "tinyglobby": "^0.2.9"
       },
       "bin": {
         "sanity-import": "src/cli.js"
@@ -12620,12 +12620,12 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.0.tgz",
-      "integrity": "sha512-+clyYQfAnNlt5a1x7CCQ6RLuTIztDfDAl6mAANvqRUlz6sVy5znCzJOhais8G6oyUyoeeaorLopO3HptVP8niA==",
-      "license": "ISC",
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.9.tgz",
+      "integrity": "sha512-8or1+BGEdk1Zkkw2ii16qSS7uVrQJPre5A9o/XkWPATkk23FZh/15BKFxPnlTy6vkljZxLqYCzzBMj30ZrSvjw==",
+      "license": "MIT",
       "dependencies": {
-        "fdir": "^6.2.0",
+        "fdir": "^6.4.0",
         "picomatch": "^4.0.2"
       },
       "engines": {
@@ -12633,9 +12633,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.2.0.tgz",
-      "integrity": "sha512-9XaWcDl0riOX5j2kYfy0kKdg7skw3IY6kA4LFT8Tk2yF9UdrADUy8D6AJuBLtf7ISm/MksumwAHE3WVbMRyCLw==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.0.tgz",
+      "integrity": "sha512-3oB133prH1o4j/L5lLW7uOCF1PlD+/It2L0eL/iAqWMB91RBbqTewABqxhj0ibBd90EEmWZq7ntIWzVaWcXTGQ==",
       "license": "MIT",
       "peerDependencies": {
         "picomatch": "^3 || ^4"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "rimraf": "^3.0.2",
     "split2": "^4.2.0",
     "tar-fs": "^2.1.1",
-    "tinyglobby": "^0.2.0"
+    "tinyglobby": "^0.2.9"
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",

--- a/src/importFromFolder.js
+++ b/src/importFromFolder.js
@@ -2,13 +2,13 @@ const fs = require('fs')
 const path = require('path')
 const debug = require('debug')('sanity:import:folder')
 const getFileUrl = require('file-url')
-const tinyglobby = require('tinyglobby')
+const {glob} = require('tinyglobby')
 const readJson = require('./util/readJson')
 const rimraf = require('./util/rimraf')
 
 module.exports = async function importFromFolder(fromDir, options, importers) {
   debug('Importing from folder %s', fromDir)
-  const dataFiles = await tinyglobby(['*.ndjson'], {cwd: fromDir, absolute: true})
+  const dataFiles = await glob(['*.ndjson'], {cwd: fromDir, absolute: true})
   if (dataFiles.length === 0) {
     throw new Error(`No .ndjson file found in ${fromDir}`)
   }
@@ -23,8 +23,8 @@ module.exports = async function importFromFolder(fromDir, options, importers) {
   debug('Importing from file %s', dataFile)
 
   const stream = fs.createReadStream(dataFile)
-  const images = await globby('images/*', {cwd: fromDir, absolute: true})
-  const files = await globby('files/*', {cwd: fromDir, absolute: true})
+  const images = await glob('images/*', {cwd: fromDir, absolute: true})
+  const files = await glob('files/*', {cwd: fromDir, absolute: true})
   const unreferencedAssets = []
     .concat(images.map((imgPath) => `image#${getFileUrl(imgPath, {resolve: false})}`))
     .concat(files.map((filePath) => `file#${getFileUrl(filePath, {resolve: false})}`))

--- a/src/importFromStream.js
+++ b/src/importFromStream.js
@@ -2,7 +2,7 @@ const fs = require('fs')
 const os = require('os')
 const path = require('path')
 const debug = require('debug')('sanity:import:stream')
-const tinyglobby = require('tinyglobby')
+const {glob} = require('tinyglobby')
 const gunzipMaybe = require('gunzip-maybe')
 const isTar = require('is-tar')
 const {noop} = require('lodash')
@@ -67,7 +67,7 @@ module.exports = (stream, options, importers) =>
     async function findAndImport() {
       debug('Tarball extracted, looking for ndjson')
 
-      const files = await tinyglobby.glob(['**/*.ndjson'], {cwd: outputPath, deep: 2, absolute: true})
+      const files = await glob(['**/*.ndjson'], {cwd: outputPath, deep: 2, absolute: true})
       if (!files.length) {
         reject(new Error('ndjson-file not found in tarball'))
         return


### PR DESCRIPTION
Fixes incorrect usage of the tinyglobby module in `importFromFolder`, and also switches to named exports for better CommonJS/ESM interop