### PR TITLE
feat: support importing content releases

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -136,6 +136,8 @@ if (!source) {
 }
 
 let operation = 'create'
+let releasesOperation = 'fail'
+
 if (flags.replace || flags.missing) {
   if (flags.replace && flags.missing) {
     printError('Cannot use both `--replace` and `--missing`')
@@ -143,6 +145,7 @@ if (flags.replace || flags.missing) {
   }
 
   operation = flags.replace ? 'createOrReplace' : 'createIfNotExists'
+  releasesOperation = flags.replace ? 'replace' : 'ignore'
 }
 
 let currentStep
@@ -151,7 +154,7 @@ let stepStart
 let spinInterval
 
 const client = createClient({
-  apiVersion: '1',
+  apiVersion: '2025-02-19',
   projectId,
   dataset,
   token,
@@ -170,6 +173,7 @@ getStream()
       assetConcurrency,
       replaceAssets,
       assetsBase: getAssetsBase(),
+      releasesOperation,
     }),
   )
   .then(({numDocs, warnings}) => {

--- a/src/cli.js
+++ b/src/cli.js
@@ -155,7 +155,6 @@ let spinInterval
 
 const client = createClient({
   apiVersion: '2025-02-19',
-  apiHost: 'https://api.sanity.work',
   projectId,
   dataset,
   token,

--- a/src/cli.js
+++ b/src/cli.js
@@ -155,6 +155,7 @@ let spinInterval
 
 const client = createClient({
   apiVersion: '2025-02-19',
+  apiHost: 'https://api.sanity.work',
   projectId,
   dataset,
   token,

--- a/src/importBatches.js
+++ b/src/importBatches.js
@@ -2,6 +2,7 @@ const pMap = require('p-map')
 const progressStepper = require('./util/progressStepper')
 const retryOnFailure = require('./util/retryOnFailure')
 const suffixTag = require('./util/suffixTag')
+const {partition} = require('lodash')
 
 const DOCUMENT_IMPORT_CONCURRENCY = 6
 
@@ -23,8 +24,7 @@ function importBatch(options, progress, batch) {
 
   return retryOnFailure(
     () => {
-      const releaseDocs = batch.filter((doc) => doc._id.startsWith('_.releases.'))
-      const docs = batch.filter((doc) => !doc._id.startsWith('_.releases.'))
+      const [releaseDocs, docs] = partition(batch, (doc) => doc._id.startsWith('_.releases.'))
 
       const docsTransaction =
         docs.length > 0

--- a/src/importBatches.js
+++ b/src/importBatches.js
@@ -51,7 +51,7 @@ function importBatch(options, progress, batch) {
       )
 
       return Promise.all([docsTransaction, ...releasesAction]).then((results) => {
-        const totalCount = results.reduce((sum, count) => sum + Number(count), 0)
+        const totalCount = results.reduce((sum, count) => sum + count, 0)
         return totalCount
       })
     },

--- a/src/importBatches.js
+++ b/src/importBatches.js
@@ -39,7 +39,7 @@ function importBatch(options, progress, batch) {
         client
           .action({
             actionType: 'sanity.action.release.import',
-            releaseId: doc._id,
+            releaseId: doc.name,
             attributes: doc,
             ifExists: releasesOperation,
           })

--- a/src/importBatches.js
+++ b/src/importBatches.js
@@ -45,7 +45,8 @@ function importBatch(options, progress, batch) {
           })
           .then(() => 1)
           .catch((err) => {
-            console.error(`Release import failed for ${doc._id}: `, err.message)
+            err.message = `Release import failed for ${doc._id}: ${err.message}`
+
             throw err
           }),
       )

--- a/src/importFromArray.js
+++ b/src/importFromArray.js
@@ -32,8 +32,11 @@ async function importDocuments(documents, options) {
 
   let filteredDocuments = documents
   // Always filter out system documents unless explicitly allowed.
+  // Release system documents are an exception to this flag.
   if (options.allowSystemDocuments !== true) {
-    filteredDocuments = documents.filter((doc) => !doc._id?.startsWith('_.'))
+    filteredDocuments = documents.filter(
+      (doc) => doc._id?.startsWith('_.releases.') || !doc._id?.startsWith('_.'),
+    )
   }
 
   // Replace relative asset paths if one is defined

--- a/src/validateOptions.js
+++ b/src/validateOptions.js
@@ -4,7 +4,9 @@ const noop = require('lodash/noop')
 
 const clientMethods = ['fetch', 'transaction', 'config']
 const allowedOperations = ['create', 'createIfNotExists', 'createOrReplace']
+const allowedReleasesOperations = ['fail', 'ignore', 'replace']
 const defaultOperation = allowedOperations[0]
+const defaultReleasesOperation = allowedReleasesOperations[0]
 
 function validateOptions(input, opts) {
   const options = defaults({}, opts, {
@@ -15,6 +17,7 @@ function validateOptions(input, opts) {
     replaceAssets: false,
     skipCrossDatasetReferences: false,
     allowSystemDocuments: false,
+    releasesOperation: defaultReleasesOperation,
   })
 
   if (!isValidInput(input)) {
@@ -47,6 +50,10 @@ function validateOptions(input, opts) {
 
   if (!allowedOperations.includes(options.operation)) {
     throw new Error(`Operation "${options.operation}" is not supported`)
+  }
+
+  if (!allowedReleasesOperations.includes(options.releasesOperation)) {
+    throw new Error(`Releases operation "${options.releasesOperation}" is not supported`)
   }
 
   if (options.assetConcurrency && options.assetConcurrency > 12) {

--- a/test/__snapshots__/import.test.js.snap
+++ b/test/__snapshots__/import.test.js.snap
@@ -42,13 +42,7 @@ exports[`accepts an array as source: employee creation 1`] = `
 }
 `;
 
-exports[`rejects on missing asset type prefix 1`] = `
-[Error: Asset type is not specified.
-\`_sanityAsset\` values must be prefixed with a type, eg image@url or file@url.
-See document with ID "deadpool", path: image._sanityAsset]
-`;
-
-exports[`skips system documents if asked: employee creation 1`] = `
+exports[`allows system documents if asked: employee creation 1`] = `
 {
   "mutations": [
     {
@@ -102,7 +96,44 @@ exports[`skips system documents if asked: employee creation 1`] = `
 }
 `;
 
-exports[`skips system documents if asked: employee creation 2`] = `
+exports[`allows system documents if asked: employee creation 2`] = `
+{
+  "actions": [
+    {
+      "actionType": "sanity.action.release.import",
+      "attributes": {
+        "_id": "_.releases.summer",
+        "_type": "system.release",
+        "name": "summer",
+        "state": "active",
+      },
+      "ifExists": "fail",
+      "releaseId": "_.releases.summer",
+    },
+  ],
+}
+`;
+
+exports[`allows system documents if asked: employee creation 3`] = `
+{
+  "actions": [
+    {
+      "actionType": "sanity.action.release.import",
+      "attributes": {
+        "_id": "_.releases.winter",
+        "_type": "system.release",
+        "name": "winter",
+        "publishAt": "2055-12-01T00:00:00.000Z",
+        "state": "scheduled",
+      },
+      "ifExists": "fail",
+      "releaseId": "_.releases.winter",
+    },
+  ],
+}
+`;
+
+exports[`allows system documents if asked: employee creation 4`] = `
 {
   "mutations": [
     {
@@ -128,4 +159,47 @@ exports[`skips system documents if asked: employee creation 2`] = `
     },
   ],
 }
+`;
+
+exports[`allows system documents if asked: employee creation 5`] = `
+{
+  "actions": [
+    {
+      "actionType": "sanity.action.release.import",
+      "attributes": {
+        "_id": "_.releases.summer",
+        "_type": "system.release",
+        "name": "summer",
+        "state": "active",
+      },
+      "ifExists": "fail",
+      "releaseId": "_.releases.summer",
+    },
+  ],
+}
+`;
+
+exports[`allows system documents if asked: employee creation 6`] = `
+{
+  "actions": [
+    {
+      "actionType": "sanity.action.release.import",
+      "attributes": {
+        "_id": "_.releases.winter",
+        "_type": "system.release",
+        "name": "winter",
+        "publishAt": "2055-12-01T00:00:00.000Z",
+        "state": "scheduled",
+      },
+      "ifExists": "fail",
+      "releaseId": "_.releases.winter",
+    },
+  ],
+}
+`;
+
+exports[`rejects on missing asset type prefix 1`] = `
+[Error: Asset type is not specified.
+\`_sanityAsset\` values must be prefixed with a type, eg image@url or file@url.
+See document with ID "deadpool", path: image._sanityAsset]
 `;

--- a/test/__snapshots__/import.test.js.snap
+++ b/test/__snapshots__/import.test.js.snap
@@ -108,7 +108,7 @@ exports[`allows system documents if asked: employee creation 2`] = `
         "state": "active",
       },
       "ifExists": "fail",
-      "releaseId": "_.releases.summer",
+      "releaseId": "summer",
     },
   ],
 }
@@ -127,7 +127,7 @@ exports[`allows system documents if asked: employee creation 3`] = `
         "state": "scheduled",
       },
       "ifExists": "fail",
-      "releaseId": "_.releases.winter",
+      "releaseId": "winter",
     },
   ],
 }
@@ -173,7 +173,7 @@ exports[`allows system documents if asked: employee creation 5`] = `
         "state": "active",
       },
       "ifExists": "fail",
-      "releaseId": "_.releases.summer",
+      "releaseId": "summer",
     },
   ],
 }
@@ -192,7 +192,7 @@ exports[`allows system documents if asked: employee creation 6`] = `
         "state": "scheduled",
       },
       "ifExists": "fail",
-      "releaseId": "_.releases.winter",
+      "releaseId": "winter",
     },
   ],
 }

--- a/test/fixtures/system-documents.ndjson
+++ b/test/fixtures/system-documents.ndjson
@@ -4,3 +4,5 @@
 {"_id": "radhe", "_type": "employee", "name": "Radhe"}
 {"_id": "robin", "_type": "employee", "name": "Robin"}
 {"_id": "matt", "_type": "employee", "name": "Matt"}
+{"_id": "_.releases.summer", "_type": "system.release", "state": "active", "name": "summer"}
+{"_id": "_.releases.winter", "_type": "system.release", "state": "scheduled", "publishAt": "2055-12-01T00:00:00.000Z", "name": "winter"}


### PR DESCRIPTION
To support releases we need:
1. to bump the API version to 2025-02-19
2. teach import to recognise release system docs

This intentionally ignores `allowSystemDocuments` flag when it comes to releases.