### PR TITLE
fix(deps): use version range for cli-core dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@oclif/core": "^4.8.0",
     "@oclif/plugin-help": "^6.2.37",
     "@sanity/asset-utils": "^2.3.0",
-    "@sanity/cli-core": "0.1.0-alpha.11",
+    "@sanity/cli-core": "^0.1.0-alpha.11",
     "@sanity/generate-help-url": "^4.0.0",
     "@sanity/mutator": "^5.8.1",
     "debug": "^4.4.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ importers:
         specifier: ^2.3.0
         version: 2.3.0
       '@sanity/cli-core':
-        specifier: 0.1.0-alpha.11
+        specifier: ^0.1.0-alpha.11
         version: 0.1.0-alpha.11(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@24.10.12)(@types/react@19.1.12)
       '@sanity/generate-help-url':
         specifier: ^4.0.0


### PR DESCRIPTION
Using a specifier does not force a specific version and pnpm can dedupe better in the main CLI codebase 