### PR TITLE
fix: distinguish unverifiable assets from missing ones

### DIFF
--- a/src/util/urlExists.ts
+++ b/src/util/urlExists.ts
@@ -21,21 +21,32 @@ function getStatusCodeForUrl(url: string): Promise<number> {
   })
 }
 
-async function urlExists(url: string): Promise<boolean> {
+async function getAssetUrlStatus(url: string): Promise<number> {
   let error: Error = new Error('Max retries exceeded')
+  let lastStatus: number | undefined
   for (let i = 0; i < MAX_RETRIES; i++) {
     try {
-      const statusCode = await getStatusCodeForUrl(url)
-      return statusCode === 200
+      const status = await getStatusCodeForUrl(url)
+      if (status < 500) {
+        return status
+      }
+      lastStatus = status
     } catch (err) {
       error = err as Error
-
-      // Wait one second before retrying the request
-      await new Promise<void>((resolve) => setTimeout(resolve, 1000))
     }
+
+    // Wait one second before retrying the request
+    await new Promise<void>((resolve) => setTimeout(resolve, 1000))
   }
 
+  if (lastStatus !== undefined) {
+    return lastStatus
+  }
   throw error
 }
 
-export {urlExists}
+async function urlExists(url: string): Promise<boolean> {
+  return (await getAssetUrlStatus(url)) === 200
+}
+
+export {getAssetUrlStatus, urlExists}

--- a/src/validateAssetDocuments.ts
+++ b/src/validateAssetDocuments.ts
@@ -8,7 +8,7 @@ import {
   type ImportOptions,
   type SanityDocument,
 } from './types.js'
-import {urlExists} from './util/urlExists.js'
+import {getAssetUrlStatus} from './util/urlExists.js'
 
 const logger = debug('sanity:import:asset-validation')
 
@@ -79,17 +79,25 @@ function getLocationFromDocument(doc: AssetDocument): {dataset: string; projectI
 async function ensureAssetUrlExists(assetDoc: AssetDocument): Promise<boolean> {
   const url = assetDoc.url!
   const start = Date.now()
-  const exists = await urlExists(url)
-  logger(`${url}: %s (%d ms)`, exists ? 'exists' : 'does not exist', Date.now() - start)
+  const status = await getAssetUrlStatus(url)
+  logger(`${url}: %d (%d ms)`, status, Date.now() - start)
 
-  if (!exists) {
-    const helpUrl = generateHelpUrl('import-asset-file-does-not-exist')
+  if (status === 200) {
+    return true
+  }
+
+  if (status !== 404) {
     throw new Error(
-      `Document ${assetDoc._id} points to a URL that does not exist (${url}). See ${helpUrl}.`,
+      `Document ${assetDoc._id} points to a URL that could not be verified (${url}): ` +
+        `server returned HTTP ${status}. ` +
+        `Re-run with --allow-failing-assets to skip URL verification.`,
     )
   }
 
-  return true
+  const helpUrl = generateHelpUrl('import-asset-file-does-not-exist')
+  throw new Error(
+    `Document ${assetDoc._id} points to a URL that does not exist (${url}). See ${helpUrl}.`,
+  )
 }
 
 function validateAssetDocumentProperties(assetDoc: AssetDocument): void {


### PR DESCRIPTION
- Asset URL verification previously reported any non-200 as "URL does not exist," which is misleading when the URL returns 5xx (e.g. transient server failure) or other non-404 statuses. Only 404 is now treated as missing; other statuses surface a distinct "could not be verified" error pointing at `--allow-failing-assets`.
- `getAssetUrlStatus` retries 5xx alongside transport errors since these are often transient.